### PR TITLE
Add CI for LSHW tests.

### DIFF
--- a/.github/workflows/lshw-beaker.yml
+++ b/.github/workflows/lshw-beaker.yml
@@ -1,6 +1,9 @@
-name: Upstream testing
+name: Beaker LSHW testing
 
-on: [push]
+on:
+  push:
+    branches:
+      - beaker
 
 jobs:
   build:

--- a/.github/workflows/lshw-beaker.yml
+++ b/.github/workflows/lshw-beaker.yml
@@ -1,0 +1,26 @@
+name: Upstream testing
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Fetch upstream LSHW
+      run: |
+        git clone https://github.com/beaker-project/lshw.git
+    - name: Compile Beaker LSHW
+      run: |
+        pushd lshw
+        make DATADIR=$(readlink -f src)
+        popd
+    - name: Compile LSHW tests
+      run: |
+        make
+    - name: Execute LSHW tests
+      run: |
+        LSHW=./lshw/src/lshw ./run-tests.sh
+ 

--- a/.github/workflows/lshw-upstream.yml
+++ b/.github/workflows/lshw-upstream.yml
@@ -1,6 +1,9 @@
-name: Upstream testing
+name: Upstream LSHW testing
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/lshw-upstream.yml
+++ b/.github/workflows/lshw-upstream.yml
@@ -1,0 +1,26 @@
+name: Upstream testing
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+  
+    steps:
+    - uses: actions/checkout@v1
+    - name: Fetch upstream LSHW
+      run: |
+        git clone https://ezix.org/src/pkg/lshw.git
+    - name: Compile LSHW
+      run: |
+        pushd lshw
+        make DATADIR=$(readlink -f src)
+        popd
+    - name: Compile LSHW tests
+      run: |
+        make
+    - name: Execute LSHW tests
+      run: |
+        LSHW=./lshw/src/lshw ./run-tests.sh
+  

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ LIBS = -ldl
 
 wrapper.so: wrapper.c
 	$(CC) $(CFLAGS) -shared -o $@ $^ $(LIBS)
+
+.PHONY: clean
+clean:
+	rm -f wrapper.so

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ CFLAGS += -std=c99 -D_GNU_SOURCE -fpic
 LIBS = -ldl
 
 wrapper.so: wrapper.c
-	$(CC) $(CFLAGS) -shared $(LIBS) -o $@ $^
+	$(CC) $(CFLAGS) -shared -o $@ $^ $(LIBS)


### PR DESCRIPTION
The patch contains GitHub Actions for both branches. Upstream and also downstream Beaker branch.